### PR TITLE
Add Docker Compose file for committed containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ $ip = docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}
 docker run -it sqlwebadmin --bind database:sqlserver2005.default --peer $ip
 ```
 
+Alternatively you can use Docker Compose along with the provided `docker-compose.yml` to bring up the containers:
+
+```
+docker-compose up
+```
+
 Grab the IP address of the `sqlwebadmin` container:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.2'
+services:
+  sqlserver2005:
+    image: sqlserver2005
+  sqlwebadmin:
+    image: sqlwebadmin
+    ports:
+      - 8099:8099
+    links:
+      - sqlserver2005
+    depends_on:
+      - sqlserver2005
+    command: --peer sqlserver2005 --bind database:sqlserver2005.default
+


### PR DESCRIPTION
This adds a docker compose file which use the partially setup containers generated during the `docker commit` stage.

To start them up:

```
docker-compose up
```

Note you'll need to shut them down properly with `docker-compose down` between demos otherwise the hab networking gets a bit messed up  when Compose tries to restart the containers